### PR TITLE
Separate Google Pay and Google Wallet strings

### DIFF
--- a/java/app/src/main/res/values/googlepay_strings.xml
+++ b/java/app/src/main/res/values/googlepay_strings.xml
@@ -2,4 +2,13 @@
 <resources>
     <string name="googlepay_button_content_description">Google Pay</string>
     <string name="buy_with_googlepay_button_content_description">Buy with Google Pay</string>
+    <string name="add_to_googlepay_button_content_description">Add To Google Pay</string>
+    <string name="checkout_with_googlepay_button_content_description">Checkout With Google Pay</string>
+    <string name="donate_with_googlepay_button_content_description">Donate With Google Pay</string>
+    <string name="order_with_googlepay_button_content_description">Order With Google Pay</string>
+    <string name="pay_with_googlepay_button_content_description">Pay With Google Pay</string>
+    <string name="book_with_googlepay_button_content_description">Book With Google Pay</string>
+    <string name="subscribe_with_googlepay_button_content_description">Subscribe With Google Pay</string>
+    <string name="text_content_description">Text for the Google Pay button</string>
+    <string name="overlay_content_description">Overlay for the Google Pay button</string>
 </resources>

--- a/java/app/src/main/res/values/googlepay_strings.xml
+++ b/java/app/src/main/res/values/googlepay_strings.xml
@@ -2,5 +2,4 @@
 <resources>
     <string name="googlepay_button_content_description">Google Pay</string>
     <string name="buy_with_googlepay_button_content_description">Buy with Google Pay</string>
-    <string name="add_to_google_wallet_button_content_description">Add to Google Wallet</string>
 </resources>

--- a/java/app/src/main/res/values/googlewallet_strings.xml
+++ b/java/app/src/main/res/values/googlewallet_strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="add_to_google_wallet_button_content_description">Add to Google Wallet</string>
+</resources>


### PR DESCRIPTION
This is to avoid collision or duplicate strings when directly importing default Google Pay Android assets.