### PR TITLE
Use strings instead of longs for price amounts to avoid rounding inconsistencies in BigDecimal

### DIFF
--- a/java/app/src/main/java/com/google/android/gms/samples/pay/activity/CheckoutActivity.java
+++ b/java/app/src/main/java/com/google/android/gms/samples/pay/activity/CheckoutActivity.java
@@ -123,7 +123,7 @@ public class CheckoutActivity extends AppCompatActivity {
 
   public void requestPayment(View view) {
     // The price provided to the API should include taxes and shipping.
-    final Task<PaymentData> task = model.getLoadPaymentDataTask(1000L);
+    final Task<PaymentData> task = model.getLoadPaymentDataTask("50.2");
     task.addOnCompleteListener(paymentDataLauncher::launch);
   }
 

--- a/java/app/src/main/java/com/google/android/gms/samples/pay/util/PaymentsUtil.java
+++ b/java/app/src/main/java/com/google/android/gms/samples/pay/util/PaymentsUtil.java
@@ -27,6 +27,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.math.RoundingMode;
 
 /**
@@ -37,8 +38,6 @@ import java.math.RoundingMode;
  * relevant to your implementation.
  */
 public class PaymentsUtil {
-
-  public static final BigDecimal CENTS_IN_A_UNIT = new BigDecimal(100);
 
   /**
    * Create a Google Pay API base request object with properties used in all requests.
@@ -232,12 +231,11 @@ public class PaymentsUtil {
    * @see <a
    * href="https://developers.google.com/pay/api/android/reference/object#PaymentDataRequest">PaymentDataRequest</a>
    */
-  public static JSONObject getPaymentDataRequest(long priceCents) {
+  public static JSONObject getPaymentDataRequest(String priceLabel) {
     try {
-      final String price = PaymentsUtil.centsToString(priceCents);
       return PaymentsUtil.getBaseRequest()
           .put("allowedPaymentMethods", getAllowedPaymentMethods())
-          .put("transactionInfo", getTransactionInfo(price))
+          .put("transactionInfo", getTransactionInfo(priceLabel))
           .put("merchantInfo", getMerchantInfo())
           .put("shippingAddressRequired", true)
           .put("shippingAddressParameters", new JSONObject()
@@ -248,17 +246,5 @@ public class PaymentsUtil {
     } catch (JSONException e) {
       return null;
     }
-  }
-
-  /**
-   * Converts cents to a string format accepted by {@link PaymentsUtil#getPaymentDataRequest}.
-   *
-   * @param cents value of the price in cents.
-   */
-  public static String centsToString(long cents) {
-    return new BigDecimal(cents)
-        .divide(CENTS_IN_A_UNIT, RoundingMode.HALF_EVEN)
-        .setScale(2, RoundingMode.HALF_EVEN)
-        .toString();
   }
 }

--- a/java/app/src/main/java/com/google/android/gms/samples/pay/viewmodel/CheckoutViewModel.java
+++ b/java/app/src/main/java/com/google/android/gms/samples/pay/viewmodel/CheckoutViewModel.java
@@ -79,11 +79,11 @@ public class CheckoutViewModel extends AndroidViewModel {
     /**
      * Creates a Task that starts the payment process with the transaction details included.
      *
-     * @param priceCents the price to show on the payment sheet.
+     * @param priceLabel the price to show on the payment sheet.
      * @return a Task with the payment information.
      */
-    public Task<PaymentData> getLoadPaymentDataTask(final long priceCents) {
-        JSONObject paymentDataRequestJson = PaymentsUtil.getPaymentDataRequest(priceCents);
+    public Task<PaymentData> getLoadPaymentDataTask(String priceLabel) {
+        JSONObject paymentDataRequestJson = PaymentsUtil.getPaymentDataRequest(priceLabel);
         if (paymentDataRequestJson == null) {
             return null;
         }

--- a/kotlin/app/src/main/java/com/google/android/gms/samples/pay/activity/CheckoutActivity.kt
+++ b/kotlin/app/src/main/java/com/google/android/gms/samples/pay/activity/CheckoutActivity.kt
@@ -67,7 +67,7 @@ class CheckoutActivity : ComponentActivity() {
     }
 
     private fun requestPayment() {
-        val task = model.getLoadPaymentDataTask(priceCents = 1000L)
+        val task = model.getLoadPaymentDataTask("50.2")
         task.addOnCompleteListener(paymentDataLauncher::launch)
     }
 }

--- a/kotlin/app/src/main/java/com/google/android/gms/samples/pay/util/PaymentsUtil.kt
+++ b/kotlin/app/src/main/java/com/google/android/gms/samples/pay/util/PaymentsUtil.kt
@@ -34,7 +34,6 @@ import java.math.RoundingMode
  * relevant to your implementation.
  */
 object PaymentsUtil {
-    val CENTS = BigDecimal(100)
 
     /**
      * Create a Google Pay API base request object with properties used in all requests.
@@ -185,10 +184,10 @@ object PaymentsUtil {
      * @return Payment data expected by your app.
      * See [PaymentDataRequest](https://developers.google.com/pay/api/android/reference/object.PaymentDataRequest)
      */
-    fun getPaymentDataRequest(priceCents: Long): JSONObject =
+    fun getPaymentDataRequest(priceLabel: String): JSONObject =
         baseRequest
             .put("allowedPaymentMethods", allowedPaymentMethods)
-            .put("transactionInfo", getTransactionInfo(priceCents.centsToString()))
+            .put("transactionInfo", getTransactionInfo(priceLabel))
             .put("merchantInfo", merchantInfo)
             .put("shippingAddressRequired", true)
             .put(
@@ -197,11 +196,3 @@ object PaymentsUtil {
                     .put("allowedCountryCodes", JSONArray(listOf("US", "GB")))
             )
 }
-
-/**
- * Converts cents to a string format accepted by [PaymentsUtil.getPaymentDataRequest].
- */
-fun Long.centsToString() = BigDecimal(this)
-    .divide(PaymentsUtil.CENTS)
-    .setScale(2, RoundingMode.HALF_EVEN)
-    .toString()

--- a/kotlin/app/src/main/java/com/google/android/gms/samples/pay/viewmodel/CheckoutViewModel.kt
+++ b/kotlin/app/src/main/java/com/google/android/gms/samples/pay/viewmodel/CheckoutViewModel.kt
@@ -88,8 +88,8 @@ class CheckoutViewModel(application: Application) : AndroidViewModel(application
      * @return a [Task] with the payment information.
      * @see [PaymentDataRequest](https://developers.google.com/android/reference/com/google/android/gms/wallet/PaymentsClient#loadPaymentData(com.google.android.gms.wallet.PaymentDataRequest)
     ) */
-    fun getLoadPaymentDataTask(priceCents: Long): Task<PaymentData> {
-        val paymentDataRequestJson = PaymentsUtil.getPaymentDataRequest(priceCents)
+    fun getLoadPaymentDataTask(priceLabel: String): Task<PaymentData> {
+        val paymentDataRequestJson = PaymentsUtil.getPaymentDataRequest(priceLabel)
         val request = PaymentDataRequest.fromJson(paymentDataRequestJson.toString())
         return paymentsClient.loadPaymentData(request)
     }


### PR DESCRIPTION
Rely on strings reflecting the behavior of the Google Pay API