### PR TITLE
Add ProductScreen previews for different UI states

### DIFF
--- a/kotlin/app/build.gradle.kts
+++ b/kotlin/app/build.gradle.kts
@@ -68,6 +68,7 @@ dependencies {
 
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("androidx.activity:activity-compose:1.8.2")
+    debugImplementation("androidx.compose.ui:ui-tooling:1.1.1")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycleVersion")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:$lifecycleVersion")
     implementation("androidx.lifecycle:lifecycle-runtime-compose:$lifecycleVersion")

--- a/kotlin/app/src/main/java/com/google/android/gms/samples/pay/ui/CheckoutLayout.kt
+++ b/kotlin/app/src/main/java/com/google/android/gms/samples/pay/ui/CheckoutLayout.kt
@@ -126,3 +126,63 @@ fun ProductScreen(
         }
     }
 }
+
+/**
+ * Wrapper to simplify previews with a provided description.
+ */
+@Composable
+private fun ProductScreenPreviewWithDescription(
+    payUiState: PaymentUiState,
+    @PreviewParameter(LoremIpsum::class) description: String
+) {
+    ProductScreen(
+        title = "Men's Tech Shell Full-Zip",
+        description = description.take(200), // Limit description to 200 characters
+        price = "$49.99",
+        image = R.drawable.ts_10_11019a,
+        onGooglePayButtonClick = {}, // No-op for previews
+        payUiState = payUiState,
+    )
+}
+
+/**
+ * Preview of ProductScreen in the initial state, where payment has not started.
+ */
+@Preview
+@Composable
+private fun ProductScreenPreviewNotStarted(
+    @PreviewParameter(LoremIpsum::class) description: String
+) {
+    ProductScreenPreviewWithDescription(
+        payUiState = PaymentUiState.NotStarted,
+        description = description
+    )
+}
+
+/**
+ * Preview of ProductScreen when Google Pay is available.
+ */
+@Preview
+@Composable
+private fun ProductScreenPreviewAvailable(
+    @PreviewParameter(LoremIpsum::class) description: String
+) {
+    ProductScreenPreviewWithDescription(
+        payUiState = PaymentUiState.Available,
+        description = description
+    )
+}
+
+/**
+ * Preview of ProductScreen after payment has been completed.
+ */
+@Preview
+@Composable
+private fun ProductScreenPreviewPaymentCompleted(
+    @PreviewParameter(LoremIpsum::class) description: String
+) {
+    ProductScreenPreviewWithDescription(
+        payUiState = PaymentUiState.PaymentCompleted(payerName = "John"),
+        description = description
+    )
+}


### PR DESCRIPTION
**Describe the changes proposed**<br>
This pull request introduces previews for the `ProductScreen` to improve testing and visualization of different UI states.

**Screenshots / Videos**<br>
Not applicable, as this change focuses on code additions

**Additional context**<br>
This change addresses the [issue 56](https://github.com/google-pay/android-quickstart/issues/56)
